### PR TITLE
Fix link to species page

### DIFF
--- a/src/components/AddressDetails/SupportedAddressDetails.tsx
+++ b/src/components/AddressDetails/SupportedAddressDetails.tsx
@@ -143,7 +143,7 @@ export function SupportedAddressDetails({ parsed, addressCount, balance, species
             </GridItem>
             <GridItem {...styles.gridValue}>
               <Link
-                href={`/species/${parsed.blockchain.name}`}
+                href={`/species/${parsed.blockchain.name.toLowerCase()}`}
                 title={`${parsed.blockchain.name} Species`}
                 color={useColorModeValue("pink.600", "pink.400")}
                 passHref


### PR DESCRIPTION
Currently links to uppercase `/Ergo` and `/Cardano`.