### PR TITLE
Robots.txt: disallow access to multiple locales in path

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,26 +1,35 @@
+/**
+ * @see { @link https://github.com/iamvishnusankar/next-sitemap#configuration-options}
+ */
+
 const linguiConfig = require("./lingui.config")
+const locales = linguiConfig.locales.filter(function (locale) {
+  return locale !== "pseudo"
+})
 
-const alternateRefs = linguiConfig.locales
-  .filter(function (locale) {
-    return locale !== "pseudo"
-  })
-  .map((locale) => ({
-    href: `${process.env.NEXT_PUBLIC_SITE_URL}/${locale}`,
-    hreflang: locale,
-  }))
+const alternateRefs = locales.map((locale) => ({
+  href: `${process.env.NEXT_PUBLIC_SITE_URL}/${locale}`,
+  hreflang: locale,
+}))
 
-const excludedPaths = linguiConfig.locales
-  .filter(function (locale) {
-    return locale !== "pseudo"
-  })
-  .map((locale) => `/${locale}/404`)
-  .concat("/404")
+const exclude = locales.map((locale) => `/${locale}/404`).concat("/404")
+
+const pathsWithMultipleLocales = locales.flatMap((v, i) => locales.map((w) => `/${v}/${w}/`))
 
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: process.env.NEXT_PUBLIC_SITE_URL,
-  generateRobotsTxt: true,
   generateIndexSitemap: false,
-  alternateRefs: alternateRefs,
-  exclude: excludedPaths,
+  alternateRefs,
+  exclude,
+  generateRobotsTxt: true,
+  robotsTxtOptions: {
+    policies: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: pathsWithMultipleLocales, // e.g. en-us/nl-nl
+      },
+    ],
+  },
 }


### PR DESCRIPTION
Nextjs i18n routing allows paths like e.g. `https://rankmywallet.com/de-de/ro-ro/species/cardano`:

- With multiple locales in path
- In this case `/de-de/ro-ro`
- Which will render the `ro-ro` language
- **But causes problems with SEO**
- For example Google Search could create `Duplicate without user-selected canonical` issues for these double paths

This PR adds the `disallow` policy to `robots.txt` for all possible route combinations and should stop Google from indexing these double-locale-pages:

```
# *
User-agent: *
Allow: /
Disallow: /de-de/de-de/
Disallow: /de-de/en-us/
Disallow: /de-de/hi-in/
Disallow: /de-de/nl-nl/
Disallow: /de-de/pt-br/
Disallow: /de-de/ro-ro/
Disallow: /en-us/de-de/
Disallow: /en-us/en-us/
Disallow: /en-us/hi-in/
Disallow: /en-us/nl-nl/
Disallow: /en-us/pt-br/
Disallow: /en-us/ro-ro/
Disallow: /hi-in/de-de/
Disallow: /hi-in/en-us/
Disallow: /hi-in/hi-in/
Disallow: /hi-in/nl-nl/
Disallow: /hi-in/pt-br/
Disallow: /hi-in/ro-ro/
Disallow: /nl-nl/de-de/
Disallow: /nl-nl/en-us/
Disallow: /nl-nl/hi-in/
Disallow: /nl-nl/nl-nl/
Disallow: /nl-nl/pt-br/
Disallow: /nl-nl/ro-ro/
Disallow: /pt-br/de-de/
Disallow: /pt-br/en-us/
Disallow: /pt-br/hi-in/
Disallow: /pt-br/nl-nl/
Disallow: /pt-br/pt-br/
Disallow: /pt-br/ro-ro/
Disallow: /ro-ro/de-de/
Disallow: /ro-ro/en-us/
Disallow: /ro-ro/hi-in/
Disallow: /ro-ro/nl-nl/
Disallow: /ro-ro/pt-br/
Disallow: /ro-ro/ro-ro/

# Host
Host: https://rankmywallet.com

# Sitemaps
Sitemap: https://rankmywallet.com/sitemap.xml
```
